### PR TITLE
メッセージ投稿機能の非同期通信の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,9 +192,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -231,7 +228,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,60 @@
+$(function(){
+  function buildHTML(message){
+    if (message.image) {
+      var html = `<div class="message">
+                    <div class="message__box">
+                      <p class="message__box__name">
+                        ${message.user_name}
+                      </p>
+                      <p class="message__box__date">
+                        ${message.created_at}
+                      </p>
+                    </div>
+                    <p class="message__text">
+                      ${message.text}
+                      <img src=${message.image} class="lower-message__image">
+                    </p>
+                  </div>`
+                return html;
+    } else {
+      var html = `<div class="message">
+                    <div class="message__box">
+                      <p class="message__box__name">
+                        ${message.user_name}
+                      </p>
+                      <p class="message__box__date">
+                        ${message.created_at}
+                      </p>
+                    </div>
+                    <p class="message__text">
+                      ${message.text}
+                    </p>
+                  </div>`
+                return html;
+    };
+  }
+
+  $(".main__footer__text").on("submit",function(e){
+    e.preventDefault()
+    var formData = new FormData(this);
+    var url = $(this).attr("action");
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data)
+      $(".main__wrapper").append(html);
+      $(".main__wrapper").animate({ scrollTop: $(".main__wrapper")[0].scrollHeight});
+      $(".main__footer__text")[0].reset();
+      $(".main__footer__submit.btn").prop("disabled", false);
+    })
+    .fail(function(){
+      alert("メッセージ送信に失敗しました");
+    })
+  })
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: "メッセージが送信されました"
+      respond_to do |format|
+        format.json
+      end      
     else 
       @messages = @group.messages.includes(:user) 
       flash.now[:alert] = "メッセージを入力してください"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.text @message.text
+json.user_name @message.user.name
+json.image @message.image_url
+json.created_at @message.created_at.strftime("%Y年%m月%d日%H時%M分")

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = "Tokyo" 
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# what
非同期通信を実装する。javascript及びJQueryを使用し、json形式のデータ取り扱うことを定義し、jbuilderで取り扱うため、message.js及びcreate.json.jbuilderを作成した。
# why
非同期通信はページを遷移することなく、ページの一部だけを更新できるメリットを有するため。

連続投稿テスト 　　　　　　→ "https://gyazo.com/f73a96a461324a75060056f3e571396c"
画像投稿テスト　　　　　　 → "https://gyazo.com/ddc313ca86341fa882e7df94da9094fd"
画像とメッセージ投稿テスト → "https://gyazo.com/a04b7731467087a2329c7fc10dffaec5"
エラーの実装テスト　　　　 → "https://gyazo.com/908e05d9554eaad803dbb3eef95ae916" 