### PR TITLE
脆弱性の排除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'rails', '~> 5.0.7', '>= 5.0.7.2'
 # Use mysql as the database for Active Record
 gem 'mysql2', '>= 0.3.18', '< 0.6.0'
 # Use Puma as the app server
-gem "puma", ">= 3.12.6"
+gem 'puma', '~> 3.12'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
@@ -64,10 +64,15 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
 gem 'haml-rails'
+
 gem 'font-awesome-sass'
+
 gem 'devise'
+
 gem 'pry-rails'
+
 gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog-aws'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       haml (>= 4.0, < 6)
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
-    i18n (1.8.3)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     image_processing (1.10.3)
       mini_magick (>= 4.9.5, < 5)
@@ -148,7 +148,7 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    loofah (2.5.0)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -161,7 +161,7 @@ GEM
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.0)
     multi_json (1.14.1)
     mysql2 (0.5.3)
     net-scp (2.0.0)
@@ -177,8 +177,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.3)
-    puma (4.3.5)
-      nio4r (~> 2.0)
+    puma (3.12.4)
     rack (2.2.2)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -270,7 +269,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.7)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -286,7 +285,7 @@ GEM
       railties (>= 5.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.5)
+    websocket-extensions (0.1.4)
 
 PLATFORMS
   ruby
@@ -312,7 +311,7 @@ DEPENDENCIES
   mini_magick
   mysql2 (>= 0.3.18, < 0.6.0)
   pry-rails
-  puma (>= 3.12.6)
+  puma (~> 3.12)
   rails (~> 5.0.7, >= 5.0.7.2)
   rails-controller-testing
   rspec-rails (~> 3.5)


### PR DESCRIPTION
# what
1. websocket-extensions ">= 0.1.5" version up
2. puma ">= 3.12.6" version up
3. activesupport ">= 5.2.4.3" version up
4. actionpack ">= 5.2.4.3" version up
5. actionview ">= 5.2.4.2" version up

# why
Dependabot alertsで表示されていた脆弱性を排除し使用者に危害を与えないため。
